### PR TITLE
Fix stdout and capture_log not working when config nodes to initialize scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ with `mix docs` from a local git checkout.
 By default, output written to stdio/stderr on nodes will be hidden. You can change this behavior for testing
 with the following node options:
 
-- Capture the entire log from a node with `capture: true`
+- Capture the entire log from a node with `capture_log: true`
 - Redirect output to a device or process with `stdout: :standard_error | :standard_io | pid`
 - Both capture _and_ redirect by setting both options. 
 
-Default values are `capture: false` and `stdout: false`
+Default values are `capture_log: false` and `stdout: false`
 
 When you capture, you can get the captured logs for a specific node with `Cluster.log(node)`. If capturing
 is not enabled, this will simply return `{:ok, ""}`, otherwise it returns `{:ok, binary}`. When you call this

--- a/lib/cluster.ex
+++ b/lib/cluster.ex
@@ -22,6 +22,8 @@ defmodule ExUnit.ClusteredCase.Cluster do
           | {:boot_timeout, pos_integer}
           | {:init_timeout, pos_integer}
           | {:post_start_functions, [callback]}
+          | {:stdout, atom | pid}
+          | {:capture_log, boolean}
 
   defstruct [
     :parent,
@@ -373,7 +375,9 @@ defmodule ExUnit.ClusteredCase.Cluster do
         config: Mix.Config.merge(global_config, Keyword.get(n, :config, [])),
         boot_timeout: Keyword.get(n, :boot_timeout, Keyword.get(opts, :boot_timeout)),
         init_timeout: Keyword.get(n, :init_timeout, Keyword.get(opts, :init_timeout)),
-        post_start_functions: global_psf ++ Keyword.get(n, :post_start_functions, [])
+        post_start_functions: global_psf ++ Keyword.get(n, :post_start_functions, []),
+        stdout: Keyword.get(n, :stdout, Keyword.get(opts, :stdout, false)),
+        capture_log: Keyword.get(n, :capture_log, Keyword.get(opts, :capture_log, false))
       ]
 
       # Strip out any nil or empty options

--- a/lib/cluster.ex
+++ b/lib/cluster.ex
@@ -334,8 +334,10 @@ defmodule ExUnit.ClusteredCase.Cluster do
     {:reply, nodenames(state), state}
   end
 
-  def handle_call(:terminate, _from, state) do
-    {:stop, :shutdown, :ok, state}
+  def handle_call(:terminate, from, state) do
+    Enum.each(nodepids(state), &ExUnit.ClusteredCase.Node.stop/1)
+    GenServer.reply(from, :ok)
+    {:stop, :shutdown, state}
   end
 
   def handle_info({:EXIT, parent, reason}, %{parent: parent} = state) do
@@ -349,12 +351,6 @@ defmodule ExUnit.ClusteredCase.Cluster do
   def handle_info({:EXIT, task, reason}, state) do
     Logger.warn("Task #{inspect(task)} failed with reason: #{inspect(reason)}")
     {:noreply, state}
-  end
-
-  def terminate(_reason, state) do
-    nodepids(state)
-    |> Task.async_stream(&ExUnit.ClusteredCase.Node.stop/1)
-    |> Enum.to_list()
   end
 
   ## Private

--- a/lib/node.ex
+++ b/lib/node.ex
@@ -7,17 +7,20 @@ defmodule ExUnit.ClusteredCase.Node do
   - `:name`, takes either a string or an atom, in either long or short form,
     this sets the node name and id.
   - `:boot_timeout`, specifies the amount of time to wait for a node to perform it's
-    initial boot sequence before timing out
+    initial boot sequence before timing out.
   - `:init_timeout`, specifies the amount of time to wait for the node agent to complete
     initializing the node (loading and starting required applications, applying configuration,
-    loading test modules, and executing post-start functions)
-  - `:erl_flags`, a list of arguments to pass to `erl` when starting the node, e.g. `["-init_debug"]`
+    loading test modules, and executing post-start functions).
+  - `:erl_flags`, a list of arguments to pass to `erl` when starting the node, e.g. `["-init_debug"]`.
   - `:env`, a list of tuples containing environment variables to export in the node's environment,
-    e.g. `[{"PORT", "8080"}]`
+    e.g. `[{"PORT", "8080"}]`.
   - `:config`, a `Keyword` list containing configuration overrides to apply to the node,
-    should be in the form of `[app: [key: value]]`
+    should be in the form of `[app: [key: value]]`.
   - `:post_start_functions`, a list of functions, either captured or in `{module, function, args}` format,
     which will be invoked on the node after it is booted and initialized. Functions must be zero-arity.
+  - `:stdout`, redirect output to a device or process with stdout: `:standard_error` | `:standard_io` | `pid`.
+  - `:capture_log`, capture the entire log from a node with `capture_log: true`,
+    can get the captured logs for a specific node with `Cluster.log(node)`.
   """
 
   alias ExUnit.ClusteredCaseError
@@ -32,6 +35,8 @@ defmodule ExUnit.ClusteredCase.Node do
           | {:env, [{String.t(), String.t()}]}
           | {:config, Keyword.t()}
           | {:post_start_functions, [fun]}
+          | {:stdout, atom | pid}
+          | {:capture_log, boolean}
   @type node_error ::
           :already_started
           | :started_not_connected

--- a/test/cluster_test.exs
+++ b/test/cluster_test.exs
@@ -31,4 +31,58 @@ defmodule ExUnit.ClusteredCase.Test.ClusterTest do
     members = Cluster.members(c)
     assert ^members = Cluster.map(c, fn -> Node.self() end)
   end
+
+  test "can capture log across a cluster" do
+    opts = [
+      boot_timeout: boot_timeout(),
+      cluster_size: 1,
+      capture_log: true,
+    ]
+    assert {:ok, c} = Cluster.start(opts)
+    [pid] = Cluster.members(c)
+    N.call(pid, IO, :puts, ["hello from cluster"])
+    assert {:ok, log} = N.log(pid)
+    assert log =~ "hello from cluster"
+  end
+
+  test "can redirect log to device across a cluster" do
+    import ExUnit.CaptureIO
+    opts = [
+      boot_timeout: boot_timeout(),
+      cluster_size: 1,
+      stdout: :standard_error
+    ]
+    assert {:ok, c} = Cluster.start(opts)
+    [pid] = Cluster.members(c)
+    assert capture_io(:standard_error, fn ->
+      N.call(pid, IO, :puts, ["stdout hello from cluster"])
+    end) =~ "stdout hello from cluster"
+  end
+
+  test "capture_log and stdout when init a cluster using nodes options" do
+    import ExUnit.CaptureIO
+    opts = [
+      nodes: [
+        [{:name, "node1"}, {:boot_timeout, boot_timeout()}, {:capture_log, true}],
+        [{:name, "node2"}, {:boot_timeout, boot_timeout()}, {:stdout, :standard_error}]
+      ]
+    ]
+    assert {:ok, c} = Cluster.start(opts)
+    [pid1, pid2] = Cluster.members(c)
+    N.call(pid1, IO, :puts, ["hello from cluster"])
+    assert {:ok, log} = N.log(pid1)
+    assert log =~ "hello from cluster"
+
+    N.call(pid2, IO, :puts, ["hello from cluster"])
+    assert {:ok, ""} = N.log(pid2)
+
+    assert capture_io(:standard_error, fn ->
+      N.call(pid1, IO, :puts, ["stdout hello from cluster"])
+    end) == ""
+
+    assert capture_io(:standard_error, fn ->
+      N.call(pid2, IO, :puts, ["stdout hello from cluster"])
+    end) =~ "stdout hello from cluster"
+  end
+
 end

--- a/test/cluster_test.exs
+++ b/test/cluster_test.exs
@@ -49,11 +49,11 @@ defmodule ExUnit.ClusteredCase.Test.ClusterTest do
     import ExUnit.CaptureIO
     opts = [
       boot_timeout: boot_timeout(),
-      cluster_size: 1,
+      cluster_size: 2,
       stdout: :standard_error
     ]
     assert {:ok, c} = Cluster.start(opts)
-    [pid] = Cluster.members(c)
+    [pid, _pid] = Cluster.members(c)
     assert capture_io(:standard_error, fn ->
       N.call(pid, IO, :puts, ["stdout hello from cluster"])
     end) =~ "stdout hello from cluster"

--- a/test/node_test.exs
+++ b/test/node_test.exs
@@ -22,10 +22,11 @@ defmodule ExUnit.ClusteredCase.Test.NodeTest do
   end
 
   test "env vars are applied as expected" do
-    env = [{"SOME_VAR", "#{inspect(self())}"}]
-    assert {:ok, pid} = start_node(env: env)
     expected = "#{inspect(self())}"
-    assert ^expected = N.call(pid, Application, :get_env, [:ex_unit_clustered_case, :env_var])
+    env = [{"SOME_VAR", expected}]
+    config = [ex_unit_clustered_case: [env_var: env]]
+    assert {:ok, pid} = start_node(config: config)
+    assert [{"SOME_VAR", ^expected}] = N.call(pid, Application, :get_env, [:ex_unit_clustered_case, :env_var])
   end
 
   test "can connect nodes to form a cluster" do

--- a/test/node_test.exs
+++ b/test/node_test.exs
@@ -10,10 +10,8 @@ defmodule ExUnit.ClusteredCase.Test.NodeTest do
 
     opts = [post_start_functions: [pingback]]
 
-    {:ok, pid} = start_node(opts)
+    assert {:ok, _} = start_node(opts)
     assert_receive {^test_pid, :pong}, 5_000
-
-    stop_node(pid)
   end
 
   test "provided configuration is applied" do
@@ -21,8 +19,6 @@ defmodule ExUnit.ClusteredCase.Test.NodeTest do
     assert {:ok, pid} = start_node(config: config)
     me = self()
     assert ^me = N.call(pid, Application, :get_env, [:ex_unit_clustered_case, :overriden_by])
-
-    stop_node(pid)
   end
 
   test "env vars are applied as expected" do
@@ -31,8 +27,6 @@ defmodule ExUnit.ClusteredCase.Test.NodeTest do
     config = [ex_unit_clustered_case: [env_var: env]]
     assert {:ok, pid} = start_node(config: config)
     assert [{"SOME_VAR", ^expected}] = N.call(pid, Application, :get_env, [:ex_unit_clustered_case, :env_var])
-
-    stop_node(pid)
   end
 
   test "can connect nodes to form a cluster" do
@@ -45,9 +39,6 @@ defmodule ExUnit.ClusteredCase.Test.NodeTest do
     assert :ok = N.connect(name1, [name2])
     assert [^name2] = N.call(name1, Node, :list, [])
     assert [^name1] = N.call(name2, Node, :list, [])
-
-    stop_node(pid1)
-    stop_node(pid2)
   end
 
   test "can restart a node with heart mode" do
@@ -60,8 +51,6 @@ defmodule ExUnit.ClusteredCase.Test.NodeTest do
     :timer.sleep(boot_timeout())
     assert N.alive?(pid)
     assert name in Node.list([:connected])
-
-    stop_node(pid)
   end
 
   test "can capture log" do
@@ -69,8 +58,6 @@ defmodule ExUnit.ClusteredCase.Test.NodeTest do
     N.call(pid, IO, :puts, ["hello from node"])
     assert {:ok, log} = N.log(pid)
     assert log =~ "hello from node"
-
-    stop_node(pid)
   end
 
   test "can redirect log to device" do
@@ -83,7 +70,5 @@ defmodule ExUnit.ClusteredCase.Test.NodeTest do
     assert capture_io(:standard_error, fn ->
       N.call(pid, IO, :puts, ["hello from node"])
     end) =~ "hello from node"
-
-    stop_node(pid)
   end
 end

--- a/test/node_test.exs
+++ b/test/node_test.exs
@@ -10,8 +10,10 @@ defmodule ExUnit.ClusteredCase.Test.NodeTest do
 
     opts = [post_start_functions: [pingback]]
 
-    assert {:ok, _} = start_node(opts)
+    {:ok, pid} = start_node(opts)
     assert_receive {^test_pid, :pong}, 5_000
+
+    stop_node(pid)
   end
 
   test "provided configuration is applied" do
@@ -19,6 +21,8 @@ defmodule ExUnit.ClusteredCase.Test.NodeTest do
     assert {:ok, pid} = start_node(config: config)
     me = self()
     assert ^me = N.call(pid, Application, :get_env, [:ex_unit_clustered_case, :overriden_by])
+
+    stop_node(pid)
   end
 
   test "env vars are applied as expected" do
@@ -27,6 +31,8 @@ defmodule ExUnit.ClusteredCase.Test.NodeTest do
     config = [ex_unit_clustered_case: [env_var: env]]
     assert {:ok, pid} = start_node(config: config)
     assert [{"SOME_VAR", ^expected}] = N.call(pid, Application, :get_env, [:ex_unit_clustered_case, :env_var])
+
+    stop_node(pid)
   end
 
   test "can connect nodes to form a cluster" do
@@ -39,6 +45,9 @@ defmodule ExUnit.ClusteredCase.Test.NodeTest do
     assert :ok = N.connect(name1, [name2])
     assert [^name2] = N.call(name1, Node, :list, [])
     assert [^name1] = N.call(name2, Node, :list, [])
+
+    stop_node(pid1)
+    stop_node(pid2)
   end
 
   test "can restart a node with heart mode" do
@@ -51,6 +60,8 @@ defmodule ExUnit.ClusteredCase.Test.NodeTest do
     :timer.sleep(boot_timeout())
     assert N.alive?(pid)
     assert name in Node.list([:connected])
+
+    stop_node(pid)
   end
 
   test "can capture log" do
@@ -58,6 +69,8 @@ defmodule ExUnit.ClusteredCase.Test.NodeTest do
     N.call(pid, IO, :puts, ["hello from node"])
     assert {:ok, log} = N.log(pid)
     assert log =~ "hello from node"
+
+    stop_node(pid)
   end
 
   test "can redirect log to device" do
@@ -70,5 +83,7 @@ defmodule ExUnit.ClusteredCase.Test.NodeTest do
     assert capture_io(:standard_error, fn ->
       N.call(pid, IO, :puts, ["hello from node"])
     end) =~ "hello from node"
+
+    stop_node(pid)
   end
 end

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -22,4 +22,8 @@ defmodule ExUnit.ClusteredCase.Support do
     |> set_boot_timeout()
     |> ExUnit.ClusteredCase.Node.start()
   end
+
+  def stop_node(node) do
+    ExUnit.ClusteredCase.Node.stop(node)
+  end
 end

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -22,8 +22,4 @@ defmodule ExUnit.ClusteredCase.Support do
     |> set_boot_timeout()
     |> ExUnit.ClusteredCase.Node.start()
   end
-
-  def stop_node(node) do
-    ExUnit.ClusteredCase.Node.stop(node)
-  end
 end


### PR DESCRIPTION
This PR contains the following updates, please review:
- Fix `stdout` and `capture_log` option missing when cluster
- Fix "test - env vars are applied as expected" failed in `test/node_test.exs`