### PR TITLE
Start erl_boot_server only in primary nodes

### DIFF
--- a/lib/app.ex
+++ b/lib/app.ex
@@ -3,16 +3,32 @@ defmodule ExUnit.ClusteredCase.App do
   use Application
 
   def start(_type, _args) do
-    # We depend on the boot server, so start it if not started yet
-    unless Process.whereis(:boot_server) do
-      {:ok, _} = :erl_boot_server.start_link([{127, 0, 0, 1}])
-    end
+    children =
+      case in_cluster_node?() do
+        true ->
+          []
 
-    children = [
-      {ExUnit.ClusteredCase.Node.Ports, []},
-      {ExUnit.ClusteredCase.Cluster.Supervisor, []}
-    ]
+        false ->
+          # We depend on the boot server, so start it if not started yet
+          unless Process.whereis(:boot_server) do
+            {:ok, _} = :erl_boot_server.start_link([{127, 0, 0, 1}])
+          end
+
+          [
+            {ExUnit.ClusteredCase.Node.Ports, []},
+            {ExUnit.ClusteredCase.Cluster.Supervisor, []}
+          ]
+      end
 
     Supervisor.start_link(children, strategy: :one_for_one)
+  end
+
+  defp in_cluster_node? do
+    node_name() =~ "ex_unit_clustered_node_"
+  end
+
+  defp node_name do
+    Node.self()
+    |> Atom.to_string()
   end
 end

--- a/lib/app.ex
+++ b/lib/app.ex
@@ -4,31 +4,25 @@ defmodule ExUnit.ClusteredCase.App do
 
   def start(_type, _args) do
     children =
-      case in_cluster_node?() do
-        true ->
-          []
+      if is_clustered_node?() do
+        # Do not start boot server/children if running as a cluster node
+        []
+      else
+        # We depend on the boot server, so start it if not started yet
+        unless Process.whereis(:boot_server) do
+          {:ok, _} = :erl_boot_server.start_link([{127, 0, 0, 1}])
+        end
 
-        false ->
-          # We depend on the boot server, so start it if not started yet
-          unless Process.whereis(:boot_server) do
-            {:ok, _} = :erl_boot_server.start_link([{127, 0, 0, 1}])
-          end
-
-          [
-            {ExUnit.ClusteredCase.Node.Ports, []},
-            {ExUnit.ClusteredCase.Cluster.Supervisor, []}
-          ]
+        [
+          {ExUnit.ClusteredCase.Node.Ports, []},
+          {ExUnit.ClusteredCase.Cluster.Supervisor, []}
+        ]
       end
 
     Supervisor.start_link(children, strategy: :one_for_one)
   end
 
-  defp in_cluster_node? do
-    node_name() =~ "ex_unit_clustered_node_"
-  end
-
-  defp node_name do
-    Node.self()
-    |> Atom.to_string()
+  defp is_clustered_node? do
+    Atom.to_string(node()) =~ "ex_unit_clustered_node_"
   end
 end


### PR DESCRIPTION
This simple PR does not start :ex_unit_clustered_case children and :erl_boot_server when called inside a clustered node.

This is needed when the app under test has a direct dependency on :ex_unit_clustered_case, which is started on each clustered node and result in boot failure because of :erl_boot_server.

See #4 , should also resolve it.