### PR TITLE
Manual stop/kill helpers

### DIFF
--- a/lib/cluster/supervisor.ex
+++ b/lib/cluster/supervisor.ex
@@ -28,6 +28,7 @@ defmodule ExUnit.ClusteredCase.Cluster.Supervisor do
         res
 
       {:error, {:already_started, pid}} ->
+        :ok = Cluster.reset(pid)
         {:ok, pid}
 
       {:error, _} = err ->

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -5,8 +5,10 @@ defmodule ExUnit.ClusteredCase.Support do
     case System.get_env("BOOT_TIMEOUT") do
       nil when is_nil(default) ->
         10_000
+
       nil ->
         default
+
       val ->
         String.to_integer(val)
     end
@@ -21,5 +23,19 @@ defmodule ExUnit.ClusteredCase.Support do
     opts
     |> set_boot_timeout()
     |> ExUnit.ClusteredCase.Node.start()
+  end
+
+  def wait_until(condition, timeout \\ 5_000) do
+    cond do
+      condition.() ->
+        :ok
+
+      timeout <= 0 ->
+        ExUnit.Assertions.flunk("Timeout reached waiting for condition")
+
+      true ->
+        Process.sleep(100)
+        wait_until(condition, timeout - 100)
+    end
   end
 end


### PR DESCRIPTION
This is a PR to fix some issues found related to #6 

Mainly I added tests for `Cluster.{stop_node, reset}`, and fixed the functionality.