### PR TITLE
fix missing clause in node_setup macro

### DIFF
--- a/lib/clustered_case.ex
+++ b/lib/clustered_case.ex
@@ -296,6 +296,9 @@ defmodule ExUnit.ClusteredCase do
         case result do
           {:error, _} = err ->
             exit(err)
+
+          _ ->
+            :ok
         end
 
         context


### PR DESCRIPTION
In node_setup/2 macro the happy path clause is missing when checking the results from the node setup rpcs.

Without this change, the following code
```
node_setup %{cluster: _cluster} do
  :ok
end
```

would raise the following exception `** (CaseClauseError) no case clause matching: [:ok]`
