### PR TITLE
Feature/hidden node toggle option

### DIFF
--- a/lib/cluster.ex
+++ b/lib/cluster.ex
@@ -24,6 +24,7 @@ defmodule ExUnit.ClusteredCase.Cluster do
           | {:post_start_functions, [callback]}
           | {:stdout, atom | pid}
           | {:capture_log, boolean}
+          | {:hidden_connect, boolean}
 
   defstruct [
     :parent,

--- a/lib/cluster.ex
+++ b/lib/cluster.ex
@@ -425,7 +425,7 @@ defmodule ExUnit.ClusteredCase.Cluster do
   defp decorate_nodes(nodes, opts) do
     for n <- nodes do
       name = Keyword.get(n, :name)
-      global_env = Keyword.get(opts, :env, [])
+      global_env = Keyword.get(opts, :env, []) |> attach_env(opts)
       global_flags = Keyword.get(opts, :erl_flags, [])
       global_config = Keyword.get(opts, :config, [])
       global_psf = Keyword.get(opts, :post_start_functions, [])
@@ -454,6 +454,12 @@ defmodule ExUnit.ClusteredCase.Cluster do
           acc
       end)
     end
+  end
+
+  defp attach_env(env, opts) do
+    value = Keyword.get(opts, :hidden_connect, true) |> Atom.to_string()
+
+    [{Utils.hidden_connect_key(), value} | env]
   end
 
   defp nodenames(%{pids: pidmap}) do

--- a/lib/clustered_case.ex
+++ b/lib/clustered_case.ex
@@ -118,6 +118,8 @@ defmodule ExUnit.ClusteredCase do
   - `config: Keyword.t`, configuration overrides to apply to all nodes in the cluster
   - `boot_timeout: integer`, the amount of time to allow for nodes to boot, in milliseconds
   - `init_timeout: integer`, the amount of time to allow for nodes to be initialized, in milliseconds
+  - `:hidden_connect`, boolean indicating if the node should be connected as hidden node.
+    Default value is `true`.
 
   ## Examples
 

--- a/lib/node/agent.ex
+++ b/lib/node/agent.ex
@@ -100,7 +100,7 @@ defmodule ExUnit.ClusteredCase.Node.Agent do
   defp exec_node_connect(manager_node) do
     hidden_connect =
       ClusterUtils.hidden_connect_key()
-      |> System.get_env()
+      |> System.get_env("true")
       |> String.to_atom()
 
     case hidden_connect do

--- a/lib/node/agent.ex
+++ b/lib/node/agent.ex
@@ -1,7 +1,6 @@
 defmodule ExUnit.ClusteredCase.Node.Agent do
   @moduledoc false
 
-  alias Mix.Utils
   alias ExUnit.ClusteredCase.Utils, as: ClusterUtils
   alias ExUnit.ClusteredCase.Node.Manager
 
@@ -140,7 +139,7 @@ defmodule ExUnit.ClusteredCase.Node.Agent do
 
       {from, :disconnect, node} when is_atom(node) ->
         disconnect_nodes(from, [node])
-        
+
       {from, :spawn_fun, fun, fun_opts} ->
         reply = spawn_fun(fun, fun_opts)
         send(from, {Node.self(), self(), reply})
@@ -180,7 +179,7 @@ defmodule ExUnit.ClusteredCase.Node.Agent do
       end
     end
   end
-  
+
   defp spawn_fun(fun, opts) when is_function(fun) do
     collect? = Keyword.get(opts, :collect, true)
     parent = self()

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -72,4 +72,8 @@ defmodule ExUnit.ClusteredCase.Utils do
     basename = <<"ex_unit_clustered_node_", suffix::binary>>
     nodename(basename)
   end
+
+  def hidden_connect_key() do
+    "HIDDEN_CONNECT"
+  end
 end


### PR DESCRIPTION
Hi, thanks for the library!
I noticed all nodes spawned are hidden by default. This can be problematic if our code relies on node monitoring or listing visible nodes.
I added new option :hidden_connect which is true by default meaning existing code can work the same.
Wasn't really sure if passing the option through env variables is good but seems better than using to_port_args/3 function.